### PR TITLE
Cleanup transit_operators

### DIFF
--- a/src/test_transit_operators.py
+++ b/src/test_transit_operators.py
@@ -2,6 +2,14 @@ from transit_operators import TransitOperators
 
 import json
 from unittest.mock import patch
+import pytest
+
+
+@patch('transit_operators.download')
+def test_parse_server_error(mock_download):
+    mock_download.return_value = None
+    with pytest.raises(ConnectionError):
+        TransitOperators('123')
 
 
 @patch('transit_operators.download')

--- a/src/transit_operators.py
+++ b/src/transit_operators.py
@@ -3,7 +3,7 @@ from downloader import download
 
 class TransitOperator:
     def __init__(self, data_dict):
-        # Explicitly store commonly used variables, others can be left to the data dict
+        # Only store needed data
         self.name = data_dict['Name']
         self.id = data_dict['Id']
         # As of the creation of this file, the API incorrectly returns the key
@@ -12,14 +12,14 @@ class TransitOperator:
             self.monitored = data_dict['Montiored']
         if 'Monitored' in data_dict:
             self.monitored = data_dict['Monitored']
-        self.data_dict = data_dict
 
 
 class TransitOperators:
     def __init__(self, api_key):
         self.__api_key = api_key
         self.operators = []
-        operators_text_list = download('operators', api_key)
-        print(operators_text_list)
-        for transit_operator in operators_text_list:
+        transit_operators_text_list = download('operators', api_key)
+        if transit_operators_text_list is None:
+            raise ConnectionError("Could not download data")
+        for transit_operator in transit_operators_text_list:
             self.operators.append(TransitOperator(transit_operator))


### PR DESCRIPTION
Don't store unneeded data, add unit test for failed download